### PR TITLE
Simplify GUI description

### DIFF
--- a/src/main/kotlin/dev/alexnader/framity/Mod.kt
+++ b/src/main/kotlin/dev/alexnader/framity/Mod.kt
@@ -80,12 +80,8 @@ class Mod(private val modId: String, private val modelVariantProvider: FramityMo
     fun item(id: String, item: Item) = ItemBuilder(id, item)
     fun block(id: String, block: Block) = BlockBuilder(id, block)
 
-    fun <E: BlockEntity> blockEntity(id: String, constructor: (BlockEntityType<E>) -> E, vararg blocks: Block): WithId<BlockEntityType<E>> {
-        lateinit var blockEntityType: WithId<BlockEntityType<E>>
-        blockEntityType = WithId(
-            id,
-            BlockEntityType.Builder.create(Supplier { constructor(blockEntityType.value) }, *blocks).build(null)
-        )
+    fun <E: BlockEntity> blockEntity(id: String, constructor: () -> E, vararg blocks: Block): WithId<BlockEntityType<E>> {
+        val blockEntityType: WithId<BlockEntityType<E>> = WithId(id, BlockEntityType.Builder.create(Supplier { constructor() }, *blocks).build(null))
         this.blockEntities[id] = BlockEntityInfo(blockEntityType.value)
         return blockEntityType
     }

--- a/src/main/kotlin/dev/alexnader/framity/blocks/SlabFrame.kt
+++ b/src/main/kotlin/dev/alexnader/framity/blocks/SlabFrame.kt
@@ -1,7 +1,5 @@
 package dev.alexnader.framity.blocks
 
-import dev.alexnader.framity.SLAB_FRAME_ENTITY
-import dev.alexnader.framity.SLAB_FRAME_SCREEN_HANDLER_TYPE
 import dev.alexnader.framity.block_entities.FrameEntity
 import dev.alexnader.framity.util.FrameDataFormat
 import net.minecraft.block.*
@@ -27,7 +25,7 @@ class SlabFrame : SlabBlock(FRAME_SETTINGS), BlockEntityProvider, Frame {
         private const val UPPER_SLOT = 1
     }
 
-    override fun createBlockEntity(view: BlockView) = FrameEntity(FORMAT, SLAB_FRAME_SCREEN_HANDLER_TYPE, SLAB_FRAME_ENTITY.value)
+    override fun createBlockEntity(view: BlockView) = FrameEntity(FORMAT)
 
     override val format = FORMAT
     override fun getSlotFor(


### PR DESCRIPTION
This PR updates the frame GUI description to use an extended factory. Using an extended factory provides access to the frame entity instance that the GUI is for, removing the need for separate block entities/screen handler types per frame format.