### PR TITLE
Invert redstone modifier

### DIFF
--- a/src/main/java/dev/alexnader/framed/mixin/local/FrameBehaviour.java
+++ b/src/main/java/dev/alexnader/framed/mixin/local/FrameBehaviour.java
@@ -88,7 +88,11 @@ public abstract class FrameBehaviour extends Block implements BlockEntityProvide
     @SuppressWarnings("deprecation")
     @Override
     public int getWeakRedstonePower(final BlockState state, final BlockView world, final BlockPos pos, final Direction direction) {
-        return state.get(PROPERTIES.HAS_REDSTONE) ? 15 : 0;
+        if (state.get(PROPERTIES.HAS_REDSTONE)) {
+            return 15 - super.getWeakRedstonePower(state, world, pos, direction);
+        } else {
+            return super.getWeakRedstonePower(state, world, pos, direction);
+        }
     }
 
     @SuppressWarnings("deprecation")


### PR DESCRIPTION
Currently, the redstone modifier makes the frame always emit a signal of 15.
It would be more useful to instead emit a signal of `15 - original`, where `original` is the redstone signal the frame would emit without the redstone modifier.

TODO:
- [x] Implement invert redstone modifier
- [x] Check compatibility with vanilla redstone